### PR TITLE
update: use golang-ci 1.17.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
 jobs:
   release:
     docker:
-      - image: okteto/golang-ci:1.16
+      - image: okteto/golang-ci:1.17.11
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Updates gaoling-ci to have docker buildx plugin installed