### PR TITLE
chore: update syncthing version to 1.27.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM syncthing/syncthing:1.24.0 AS syncthing
+FROM syncthing/syncthing:1.27.1 AS syncthing
 FROM okteto/remote:0.4.2 AS remote
 FROM okteto/supervisor:0.2.1 AS supervisor
 FROM okteto/clean:0.1.6 AS clean


### PR DESCRIPTION
Updates synching to latest stable release 1.27.1: [Release notes](https://github.com/syncthing/syncthing/releases/tag/v1.27.1)