### PR TITLE
Added trivy to push github action workflow. 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,6 @@ jobs:
         with:
           image-ref: 'okteto/bin:1.6.0'
           format: 'table'
-          exit-code: '1'
 
       - name: Move cache
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,12 +52,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: 'okteto/bin:1.6.0'
-          format: 'table'
-
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,12 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: 'okteto/bin:1.6.0'
+          format: 'table'
+
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,7 @@ jobs:
         with:
           image-ref: 'okteto/bin:1.6.0'
           format: 'table'
+          exit-code: '1'
 
       - name: Move cache
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -62,6 +62,12 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: 'okteto/bin:${{ github.event.release.tag_name }}'
+          format: 'table'
+
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache


### PR DESCRIPTION
This PR mainly adds a trivy scan for the image generated on a release.

Temporary I added a step also in the build one for testing purposes. It cannot be added to build workflow as we are not pushing the image.

This is how it looks like an execution of the scan: https://github.com/okteto/bin-image/actions/runs/10668933998/job/29569730921#step:9:27.

It is configure to not fail in case some vul is found