### PR TITLE
Updated clean dependency to latest version and push also latest tag when publishing

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -57,7 +57,7 @@ jobs:
           build-args: |
             OKTETO_BIN_TAG=${{ github.event.release.tag_name }}
           tags: |
-            okteto/bin:${{ github.event.release.tag_name }}
+            okteto/bin:${{ github.event.release.tag_name }},okteto/bin:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM syncthing/syncthing:1.27.10 AS syncthing
 FROM okteto/remote:0.6.0 AS remote
 FROM okteto/supervisor:0.4.0 AS supervisor
-FROM okteto/clean:0.2.0 AS clean
+FROM okteto/clean:0.2.1 AS clean
 
 FROM busybox
 


### PR DESCRIPTION
I created a new version of clean to fix a few vulnerabilities that were being reported (I only had to create a new release to rebuild the image). 

```
2024-09-03T10:17:16+02:00	INFO	Need to update DB
2024-09-03T10:17:16+02:00	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
52.71 MiB / 52.71 MiB [--------------------------------------------------------------------------------------------------------------------------] 100.00% 25.19 MiB p/s 2.3s
2024-09-03T10:17:20+02:00	INFO	Vulnerability scanning is enabled
2024-09-03T10:17:20+02:00	INFO	Secret scanning is enabled
2024-09-03T10:17:20+02:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-09-03T10:17:20+02:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-09-03T10:17:22+02:00	INFO	Number of language-specific files	num=1
2024-09-03T10:17:22+02:00	INFO	[gobinary] Detecting vulnerabilities...
2024-09-03T10:17:22+02:00	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

usr/local/bin/clean (gobinary)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.2            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24788 │ HIGH     │        │                   │ 1.22.3          │ golang: net: malformed DNS message can cause infinite loop   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24788                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24789 │ MEDIUM   │        │                   │ 1.21.11, 1.22.4 │ golang: archive/zip: Incorrect handling of certain ZIP files │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24789                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24791 │          │        │                   │ 1.21.12, 1.22.5 │ net/http: Denial of service due to improper 100-continue     │
│         │                │          │        │                   │                 │ handling in net/http                                         │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24791                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```

After this, there are no more vulnerabilities reported.

I also added a change to push the changes to `latest` tag. In that way, we can always scan `okteto/bin:latest` when releasing CLI without having to keep updated the version of the bin image we use